### PR TITLE
add semicolon for unexperted error

### DIFF
--- a/then.js
+++ b/then.js
@@ -7,7 +7,7 @@
 // **License:** MIT
 
 /* global module, define, setImmediate, console */
-(function (root, factory) {
+;(function (root, factory) {
   'use strict';
 
   if (typeof module === 'object' && typeof module.exports === 'object') {


### PR DESCRIPTION
在文件打包时，如果前面的代码产生了一个表达式与then.js链接到一起：

`A(function(){})(this, function(){})`

就出错了。

还有一种写法是

`+function(){}(this, function(){})`
