### PR TITLE
Series optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,20 @@ Thenjs.series([
 });
 ```
 
++ taskFn 形式为 function(cont,result){} 时,通过result可获取之前项的返回值
+
+```js
+Thenjs.series([
+  function (cont,result) { typeof result === 'undefined'; cont(null,100) },
+  function (cont,result) { assert.equal(100,result[0]);cont(null, 99); },
+  function (cont,result) { assert.equal(100,result[0]); assert.equal(99,result[1]);cont(null, 98); }
+])
+.then(function (cont, result) {
+  console.log(result);
+});
+
+```
+
 ### Thenjs.parallelLimit(tasksArray, limit, [debug])
 
 `tasksArray` 是一个函数（同步或异步）数组，并行执行，最大并行数量为 `limit`，当并行队列中某一项完成时，会立即补上，也就是说，并发数会一直保持在 `limit`，除非待运行任务不足。返回一个新的 `Thenjs` 对象。

--- a/test/index.js
+++ b/test/index.js
@@ -410,65 +410,65 @@ describe('Thenjs', function () {
       var pending = []
       Then()
         .series([
-            function (cont, result) {
-              pending.push(1)
-              assert.strictEqual(pending.length, 1)
-              assert.equal('undefined', typeof result);
-              cont(null, 1)
-            },
-            function (cont, result) {
-              assert.strictEqual(pending.length, 1)
+          function (cont, result) {
+            pending.push(1)
+            assert.strictEqual(pending.length, 1)
+            assert.equal('undefined', typeof result)
+            cont(null, 1)
+          },
+          function (cont, result) {
+            assert.strictEqual(pending.length, 1)
+            setTimeout(function () {
+              pending.push(2)
+              assert.strictEqual(pending.length, 2)
+              assert.equal(1, result[0])
+              cont(null, 2, 3)
+            })
+          },
+          function (cont, result) {
+            pending.push(3)
+            assert.strictEqual(pending.length, 3)
+            assert.equal(1, result[0])
+            assert.equal(2, result[1])
+            cont(null, 4)
+          }
+        ])
+        .then(function (cont, res) {
+          assert.deepEqual(pending, [1, 2, 3])
+          assert.deepEqual(res, [1, 2, 4])
+          cont(null, [
+            function (cont) {
               setTimeout(function () {
-                pending.push(2)
-                assert.strictEqual(pending.length, 2)
-                assert.equal(1, result[0])
-                cont(null, 2, 3)
+                cont(null, x)
               })
             },
             function (cont, result) {
-              pending.push(3)
-              assert.strictEqual(pending.length, 3)
-              assert.equal(1, result[0])
-              assert.equal(2, result[1])
-              cont(null, 4)
-            }
-          ])
-          .then(function (cont, res) {
-            assert.deepEqual(pending, [1, 2, 3])
-            assert.deepEqual(res, [1, 2, 4])
-            cont(null, [
-              function (cont) {
-                setTimeout(function () {
-                  cont(null, x)
-                })
-              },
-              function (cont, result) {
-                assert.deepEqual(x, result[0])
-                cont(null, null)
-              }
-            ])
-          })
-          .series(null)
-          .then(function (cont, res) {
-            assert.deepEqual(res, [x, null])
-            cont(null, x)
-          })
-          .series([
-            function (cont) {
-              cont(null, x)
-            },
-            function (cont, result) {
               assert.deepEqual(x, result[0])
-              noneFn1()
-              cont(null, x)
+              cont(null, null)
             }
           ])
-          .fin(function (cont, err, res) {
-            assert.strictEqual(err instanceof Error, true)
-            assert.strictEqual(err.message.indexOf('noneFn1') >= 0, true)
-            assert.strictEqual(res, void 0)
-            cont()
-          }).toThunk()(done)
+        })
+        .series(null)
+        .then(function (cont, res) {
+          assert.deepEqual(res, [x, null])
+          cont(null, x)
+        })
+        .series([
+          function (cont) {
+            cont(null, x)
+          },
+          function (cont, result) {
+            assert.deepEqual(x, result[0])
+            noneFn1()
+            cont(null, x)
+          }
+        ])
+        .fin(function (cont, err, res) {
+          assert.strictEqual(err instanceof Error, true)
+          assert.strictEqual(err.message.indexOf('noneFn1') >= 0, true)
+          assert.strictEqual(res, void 0)
+          cont()
+        }).toThunk()(done)
     })
 
     it('.each', function (done) {

--- a/test/index.js
+++ b/test/index.js
@@ -406,6 +406,71 @@ describe('Thenjs', function () {
         }).toThunk()(done)
     })
 
+    it('.series-result', function (done) {
+        var pending = []
+        Then()
+          .series([
+            function (cont,result) {
+              pending.push(1)
+              assert.strictEqual(pending.length, 1)
+              assert.equal('undefined',typeof result);
+              cont(null, 1)
+            },
+            function (cont,result) {
+              assert.strictEqual(pending.length, 1)
+              setTimeout(function () {
+                pending.push(2)
+                assert.strictEqual(pending.length, 2)
+                assert.equal(1,result[0])
+                cont(null, 2, 3)
+              })
+            },
+            function (cont,result) {
+              pending.push(3)
+              assert.strictEqual(pending.length, 3)
+              assert.equal(1,result[0])
+              assert.equal(2,result[1])
+              cont(null, 4)
+            }
+          ])
+          .then(function (cont, res) {
+            assert.deepEqual(pending, [1, 2, 3])
+            assert.deepEqual(res, [1, 2, 4])
+            cont(null, [
+              function (cont) {
+                setTimeout(function () {
+                  cont(null, x)
+                })
+              },
+              function (cont,result) {
+                assert.deepEqual(x,result[0]);
+                cont(null, null)
+              }
+            ])
+          })
+          .series(null)
+          .then(function (cont, res) {
+            assert.deepEqual(res, [x, null])
+            cont(null, x)
+          })
+          .series([
+            function (cont) {
+              cont(null, x)
+            },
+            function (cont,result) {
+              assert.deepEqual(x,result[0]);
+              noneFn1()
+              cont(null, x)
+            }
+          ])
+          .fin(function (cont, err, res) {
+            assert.strictEqual(err instanceof Error, true)
+            assert.strictEqual(err.message.indexOf('noneFn1') >= 0, true)
+            assert.strictEqual(res, void 0)
+            cont()
+          }).toThunk()(done)
+      })
+
     it('.each', function (done) {
       var pending = []
       Then()

--- a/test/index.js
+++ b/test/index.js
@@ -407,29 +407,29 @@ describe('Thenjs', function () {
     })
 
     it('.series-result', function (done) {
-        var pending = []
-        Then()
-          .series([
-            function (cont,result) {
+      var pending = []
+      Then()
+        .series([
+            function (cont, result) {
               pending.push(1)
               assert.strictEqual(pending.length, 1)
-              assert.equal('undefined',typeof result);
+              assert.equal('undefined', typeof result);
               cont(null, 1)
             },
-            function (cont,result) {
+            function (cont, result) {
               assert.strictEqual(pending.length, 1)
               setTimeout(function () {
                 pending.push(2)
                 assert.strictEqual(pending.length, 2)
-                assert.equal(1,result[0])
+                assert.equal(1, result[0])
                 cont(null, 2, 3)
               })
             },
-            function (cont,result) {
+            function (cont, result) {
               pending.push(3)
               assert.strictEqual(pending.length, 3)
-              assert.equal(1,result[0])
-              assert.equal(2,result[1])
+              assert.equal(1, result[0])
+              assert.equal(2, result[1])
               cont(null, 4)
             }
           ])
@@ -442,8 +442,8 @@ describe('Thenjs', function () {
                   cont(null, x)
                 })
               },
-              function (cont,result) {
-                assert.deepEqual(x,result[0]);
+              function (cont, result) {
+                assert.deepEqual(x, result[0])
                 cont(null, null)
               }
             ])
@@ -457,8 +457,8 @@ describe('Thenjs', function () {
             function (cont) {
               cont(null, x)
             },
-            function (cont,result) {
-              assert.deepEqual(x,result[0]);
+            function (cont, result) {
+              assert.deepEqual(x, result[0])
               noneFn1()
               cont(null, x)
             }
@@ -469,7 +469,7 @@ describe('Thenjs', function () {
             assert.strictEqual(res, void 0)
             cont()
           }).toThunk()(done)
-      })
+    })
 
     it('.each', function (done) {
       var pending = []

--- a/then.js
+++ b/then.js
@@ -408,7 +408,7 @@
       if (++i > end) return cont(null, result)
       // 先同步执行，嵌套达到 maxTickDepth 时转成一次异步执行
       run = --stack > 0 ? carry : (stack = maxTickDepth, defer)
-      run(cont, tasks[i], next)
+      run(cont, tasks[i], next,result)
     }
   }
 

--- a/then.js
+++ b/then.js
@@ -408,7 +408,7 @@
       if (++i > end) return cont(null, result)
       // 先同步执行，嵌套达到 maxTickDepth 时转成一次异步执行
       run = --stack > 0 ? carry : (stack = maxTickDepth, defer)
-      run(cont, tasks[i], next,result)
+      run(cont, tasks[i], next, result)
     }
   }
 


### PR DESCRIPTION
1.给series方法增加串行中的子项获取已执行子项的返回值能力.
2.目的: 可以解决for循环的异步任务,可以替代递归的方式.